### PR TITLE
Potion Shop and Multiworld Player compatibility

### DIFF
--- a/hooks.asm
+++ b/hooks.asm
@@ -1146,10 +1146,21 @@ NOP #2
 org $05F55F ; <- 2F55F - sprite_potion_shop.asm : 59
 JSL.l LoadPowder
 ;--------------------------------------------------------------------------------
-org $05F681 ; <- 2F681 - sprite_potion_shop.asm : 234
-JSL.l DrawPowder
-RTS
-NOP #8
+org $05F66B ; <- 2F681 - sprite_potion_shop.asm : 234
+.oam_groups:
+    dw 0, 0 : db $24, $15, $00, $12
+    dw 0, 0 : db $24, $15, $00, $03
+;--------------------------------------------------------------------------------
+org $05F67B ; <- 2F681 - sprite_potion_shop.asm : 234
+    ; ; Interesting thing to note: This will end up drawing the same sprite
+    ; ; twice (in the same location), for whatever reason.
+    LDA.b #$02 : STA $06
+                 STZ $07
+    LDA.b #$6B : STA $08
+    LDA.b #$F6 : STA $09
+
+    JSL DrawPowder
+    RTS
 ;--------------------------------------------------------------------------------
 org $05F65D ; <- 2F65D - sprite_potion_shop.asm : 198
 JSL.l CollectPowder
@@ -1164,6 +1175,26 @@ JSL.l DrawMushroom
 ;--------------------------------------------------------------------------------
 org $05EE97 ; <- 2EE97 - sprite_mushroom.asm : 81
 NOP #14
+;--------------------------------------------------------------------------------
+org $05F529 ; <- 2F52C - sprite_potion_shop.asm
+JSL SpritePrep_ShopKeeper
+LDX #$0
+JSR $F539 ; <- powder spawn here
+RTS
+;--------------------------------------------------------------------------------
+org $05F568 ; <- 2F568 - sprite_potion_shop.asm
+LDA #$b0 : STA $0D00, Y : LDA #$90 : STA $0D10, Y ; manually set position of powder item.  does not fix the problem
+LDA #$21 : STA $0D20, Y : LDA #$12 : STA $0D30, Y 
+JMP $F61D
+;--------------------------------------------------------------------------------
+org $05F633 ; <- 2F633 - sprite_potion_shop.asm
+LDA $0E80, X : BNE +
+JSL Sprite_ShopKeeperPotion ;; TODO: i don't remember prices being set on top of the player 
+JSR $F893 ; <- witch behavior here
+RTS
++
+JSR $F644 ; <- powder behavior here 
+RTS
 ;--------------------------------------------------------------------------------
 org $05EB1D ; <- 2EB1D - sprite_bottle_vendor.asm : 158
 JSL.l Multiworld_BottleVendor_GiveBottle

--- a/hooks.asm
+++ b/hooks.asm
@@ -1152,13 +1152,6 @@ org $05F66B ; <- 2F681 - sprite_potion_shop.asm : 234
     dw 0, 0 : db $24, $15, $00, $03
 ;--------------------------------------------------------------------------------
 org $05F67B ; <- 2F681 - sprite_potion_shop.asm : 234
-    ; ; Interesting thing to note: This will end up drawing the same sprite
-    ; ; twice (in the same location), for whatever reason.
-    LDA.b #$02 : STA $06
-                 STZ $07
-    LDA.b #$6B : STA $08
-    LDA.b #$F6 : STA $09
-
     JSL DrawPowder
     RTS
 ;--------------------------------------------------------------------------------

--- a/hooks.asm
+++ b/hooks.asm
@@ -1146,14 +1146,9 @@ NOP #2
 org $05F55F ; <- 2F55F - sprite_potion_shop.asm : 59
 JSL.l LoadPowder
 ;--------------------------------------------------------------------------------
-org $05F66B ; <- 2F681 - sprite_potion_shop.asm : 234
-.oam_groups:
-    dw 0, 0 : db $24, $15, $00, $12
-    dw 0, 0 : db $24, $15, $00, $03
-;--------------------------------------------------------------------------------
-org $05F67B ; <- 2F681 - sprite_potion_shop.asm : 234
-    JSL DrawPowder
-    RTS
+org $05F67B ; <- 2F67B - sprite_potion_shop.asm : 234
+JSL DrawPowder
+RTS
 ;--------------------------------------------------------------------------------
 org $05F65D ; <- 2F65D - sprite_potion_shop.asm : 198
 JSL.l CollectPowder

--- a/inventory.asm
+++ b/inventory.asm
@@ -966,6 +966,11 @@ LoadPowder:
 	%GetPossiblyEncryptedItem(WitchItem, SpriteItemValues)
 	STA $0DA0, Y ; Store item type
 	JSL.l PrepDynamicTile
+	STA $7F505E
+	LDA #$00
+	STA $7F505F
+	STA $7F5060
+	STA $7F5061
 RTL
 ;--------------------------------------------------------------------------------
 
@@ -999,12 +1004,6 @@ DrawPowder:
 ;	LDA $0DA0, X ; Retrieve stored item type
 ;	JSL.l DrawDynamicTile
 ;	.defer
-;    LDA.b #$01 : STA $06
-;                 STZ $07
-;    LDA.b #$6B : STA $08
-;    LDA.b #$F6 : STA $09
-;
-	JSL Sprite_DrawMultiple_player_deferred
 RTL
 ;--------------------------------------------------------------------------------
 

--- a/inventory.asm
+++ b/inventory.asm
@@ -992,7 +992,8 @@ RTL
 ;--------------------------------------------------------------------------------
 !REDRAW = "$7F5000"
 ;--------------------------------------------------------------------------------
-DrawPowder:
+DrawPowder: 
+;	this fights with the shopkeep code, so had to move the powder draw there
 ;	LDA $02DA : BNE .defer ; defer if link is buying a potion
 ;	LDA.l !REDRAW : BEQ +
 ;		%GetPossiblyEncryptedPlayerID(WitchItem_Player) : STA !MULTIWORLD_SPRITEITEM_PLAYER_ID

--- a/inventory.asm
+++ b/inventory.asm
@@ -988,17 +988,23 @@ RTL
 !REDRAW = "$7F5000"
 ;--------------------------------------------------------------------------------
 DrawPowder:
-	LDA $02DA : BNE .defer ; defer if link is buying a potion
-	LDA.l !REDRAW : BEQ +
-		%GetPossiblyEncryptedPlayerID(WitchItem_Player) : STA !MULTIWORLD_SPRITEITEM_PLAYER_ID
-		LDA $0DA0, X ; Retrieve stored item type
-		JSL.l PrepDynamicTile
-		LDA #$00 : STA.l !REDRAW ; reset redraw flag
-		BRA .defer
-	+
-	LDA $0DA0, X ; Retrieve stored item type
-	JSL.l DrawDynamicTile
-	.defer
+;	LDA $02DA : BNE .defer ; defer if link is buying a potion
+;	LDA.l !REDRAW : BEQ +
+;		%GetPossiblyEncryptedPlayerID(WitchItem_Player) : STA !MULTIWORLD_SPRITEITEM_PLAYER_ID
+;		LDA $0DA0, X ; Retrieve stored item type
+;		JSL.l PrepDynamicTile
+;		LDA #$00 : STA.l !REDRAW ; reset redraw flag
+;		BRA .defer
+;	+
+;	LDA $0DA0, X ; Retrieve stored item type
+;	JSL.l DrawDynamicTile
+;	.defer
+;    LDA.b #$01 : STA $06
+;                 STZ $07
+;    LDA.b #$6B : STA $08
+;    LDA.b #$F6 : STA $09
+;
+	JSL Sprite_DrawMultiple_player_deferred
 RTL
 ;--------------------------------------------------------------------------------
 

--- a/shopkeeper.asm
+++ b/shopkeeper.asm
@@ -616,7 +616,7 @@ Setup_ShopItemCollisionHitbox:
 	REP #$20 ; set 16-bit accumulator
 	PHA : PHY
 		LDA !SHOP_TYPE : AND.w #$0003 : DEC : ASL : TAY
-		LDA $A0 : CMP.l #$109 : BNE + : INY #6 : + 
+		LDA $A0 : CMP.l #$09 : BNE + : INY #6 : + 
 		LDA.w Shopkeeper_DrawNextItem_item_offsets_idx, Y : STA $00 ; get table from the table table
 	PLY : PLA
     

--- a/shopkeeper.asm
+++ b/shopkeeper.asm
@@ -715,6 +715,7 @@ Shopkeeper_DrawItems:
 	+ CMP.b #$01 : BNE + : ++
 		JSR.w Shopkeeper_DrawNextItem
 	+
+	LDA $A0 : CMP.l #$109 : BNE +
 	LDA !NPC_FLAGS_2 : AND.b #$20 : BNE +
 		LDX.b #$0C : LDY.b #$03 : JSR.w Shopkeeper_DrawNextItem
 	+

--- a/tables.asm
+++ b/tables.asm
@@ -1634,10 +1634,10 @@ db $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF
 
 org $30C900 ; PC 0x184900 - 0x184FFF - max 224 entries
 ShopContentsTable:
-;db [id][item][price-low][price-high][max][repl_id][repl_price-low][repl_price-high]
-db $01, $51, $64, $00, $07, $FF, $00, $00
-db $01, $53, $64, $00, $07, $FF, $00, $00
-db $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF
+;db [id][item][price-low][price-high][max][repl_id][repl_price-low][repl_price-high][player]
+db $01, $51, $64, $00, $07, $FF, $00, $00, $00
+db $01, $53, $64, $00, $07, $FF, $00, $00, $00 
+db $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $00 
 
 ; Fix spawning with more hearts than capacity when less than 3 heart containers
 LowHeartFix:


### PR DESCRIPTION
Notable fixes require DrawPowder to be removed in favor of treating Powder like a shop object.

Adding extra entry into the RAM stored shop table to accommodate Powder fix.

Added extra byte to end of shop table entry in ROM to accommodate player information.