### PR TITLE
Fixed accidental byte/long value 109, potion refill variable reset, etc

### DIFF
--- a/hooks.asm
+++ b/hooks.asm
@@ -1164,7 +1164,7 @@ JSL.l DrawMushroom
 org $05EE97 ; <- 2EE97 - sprite_mushroom.asm : 81
 NOP #14
 ;--------------------------------------------------------------------------------
-org $05F529 ; <- 2F52C - sprite_potion_shop.asm
+org $05F529 ; <- 2F529 - sprite_potion_shop.asm
 JSL SpritePrep_ShopKeeper
 LDX #$0
 JSR $F539 ; <- powder spawn here
@@ -1179,8 +1179,7 @@ org $05F633 ; <- 2F633 - sprite_potion_shop.asm
 LDA $0E80, X : BNE +
 JSL Sprite_ShopKeeperPotion ;; TODO: i don't remember prices being set on top of the player 
 JSR $F893 ; <- witch behavior here
-RTS
-+
+RTS : +
 JSR $F644 ; <- powder behavior here 
 RTS
 ;--------------------------------------------------------------------------------

--- a/inventory.asm
+++ b/inventory.asm
@@ -994,17 +994,17 @@ RTL
 ;--------------------------------------------------------------------------------
 DrawPowder: 
 ;	this fights with the shopkeep code, so had to move the powder draw there
-;	LDA $02DA : BNE .defer ; defer if link is buying a potion
-;	LDA.l !REDRAW : BEQ +
-;		%GetPossiblyEncryptedPlayerID(WitchItem_Player) : STA !MULTIWORLD_SPRITEITEM_PLAYER_ID
-;		LDA $0DA0, X ; Retrieve stored item type
-;		JSL.l PrepDynamicTile
-;		LDA #$00 : STA.l !REDRAW ; reset redraw flag
-;		BRA .defer
-;	+
+	LDA $02DA : BNE .defer ; defer if link is buying a potion
+	LDA.l !REDRAW : BEQ +
+		%GetPossiblyEncryptedPlayerID(WitchItem_Player) : STA !MULTIWORLD_SPRITEITEM_PLAYER_ID
+		LDA $0DA0, X ; Retrieve stored item type
+		JSL.l PrepDynamicTile
+		LDA #$00 : STA.l !REDRAW ; reset redraw flag
+		BRA .defer
+	+
 ;	LDA $0DA0, X ; Retrieve stored item type
 ;	JSL.l DrawDynamicTile
-;	.defer
+	.defer
 RTL
 ;--------------------------------------------------------------------------------
 


### PR DESCRIPTION
Also fixes flicker when getting potion shop items

line 618 in shopkeeper.asm was bugged with the incorrect length of cmp.