### PR TITLE
Remove glitchy Rain overlays

### DIFF
--- a/LTTP_RND_GeneralBugfixes.asm
+++ b/LTTP_RND_GeneralBugfixes.asm
@@ -201,6 +201,7 @@ incsrc playername.asm
 incsrc decryption.asm
 incsrc hashalphabet.asm
 incsrc inverted.asm
+incsrc removerain.asm
 incsrc invertedmaps.asm
 incsrc newhud.asm
 incsrc compasses.asm

--- a/hooks.asm
+++ b/hooks.asm
@@ -1616,6 +1616,10 @@ JSL.l SetUncleRainState : RTS
 ;org $0280DD ; <- 100DD - Bank02.asm:298 - (LDA $7EF3C5 : CMP.b #$02 : BCC .indoors)
 ;JSL.l ForceLinksHouse
 ;--------------------------------------------------------------------------------
+org $02A3C4 ; <- 124CD - Bank02.asm:298 - (LDA $7EF3C5 : CMP.b #$02 : BCC .indoors)
+JSL.l Overworld_RemoveRainLong : BNE + : RTL : +
+NOP #15
+;--------------------------------------------------------------------------------
 org $05EDDF ; <- 2EDDF - sprite_zelda.asm:398 - (LDA.b #$02 : STA $7EF3C5)
 JSL.l EndRainState : NOP #2
 ;--------------------------------------------------------------------------------

--- a/removerain.asm
+++ b/removerain.asm
@@ -1,0 +1,18 @@
+Overworld_RemoveRainLong:
+{
+    LDA $8A : AND.b #$BF : CMP #$03 : BEQ ++ : CMP #$05 : BEQ ++ : CMP #$07 : BNE + : ++ ; any death mountain rooms
+        BRA .endNoRain
+    +
+
+    LDA $8A : CMP #$70 : BNE + 
+        LDA $7EF2F0 : AND.b #$20 : BNE .endNoRain
+        LDA $0410 : ORA $0416 : ORA $0418 : BNE .endNoRain ; if we're transitioning at a direction
+            BRA .endWithRain
+    +
+
+    LDA $7EF3C5 : CMP.b #$02 : !BGE .endNoRain
+    .endWithRain
+    LDA #$FF : RTL
+    .endNoRain
+    LDA #$00 : RTL
+}


### PR DESCRIPTION
Removes Rain from Death Mountain during rescue and when transitioning to Misery Mire without using a flute or doorway/connector